### PR TITLE
Create an org-wide CODE_OF_CONDUCT.md file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+OpenTelemetry follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).


### PR DESCRIPTION
By creating this org-wide CoC file, all org project with out a CoC will have a CoC link appear on their landing page (in the group of links that includes a link to the license).

Per discussion with @caniszczyk.

/cc @nate-double-u @tedsuo 
