### PR TITLE
Rename master to main in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ This security policy applies to all projects under the [open-telemetry organizat
 
 ## Supported Versions
 
-The OpenTelemetry project provides community support only for the last minor version: bug fixes are released either as part of the next minor version or as an on-demand patch version. Independent of which version is next, all patch versions are cumulative, meaning that they represent the state of our `master` branch at the moment of the release. For instance, if the latest version is 0.10.0, bug fixes are released either as part of 0.11.0 or 0.10.1.
+The OpenTelemetry project provides community support only for the last minor version: bug fixes are released either as part of the next minor version or as an on-demand patch version. Independent of which version is next, all patch versions are cumulative, meaning that they represent the state of our `main` branch at the moment of the release. For instance, if the latest version is 0.10.0, bug fixes are released either as part of 0.11.0 or 0.10.1.
 
 Security fixes are given priority and might be enough to cause a new version to be released.
 


### PR DESCRIPTION
This replaces a leftover mention of the formerly used `master` branch.

In a follow-up we should consider rewriting or removing the entire paragraph as this will likely not uniformly apply to all repositories/artifacts in the same manner.
cc @open-telemetry/technical-committee 