### PR TITLE
Add README to otel github org

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and behavior.
   ·
   <a href="https://opentelemetry.io/docs/getting-started/">Get Started 🔭</a>
   ·
-  <a href="https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md">Contribute 🫶</a>
+  <a href="https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md">Contribute 😍</a>
   ·
   <a href="https://opentelemetry.io/docs/demo/">Try the demo 🎓</a>
 </p>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-OpenTelemetry is a collection of tools, APIs, and SDKs. Use it to
+OpenTelemetry is a collection of APIs, SDKs, and tools. Use it to
 instrument, generate, collect, and export telemetry data (<a href="https://opentelemetry.io/docs/concepts/signals/metrics/">metrics</a>, <a href="https://opentelemetry.io/docs/concepts/signals/logs/">logs</a> and <a href="https://opentelemetry.io/docs/concepts/signals/traces/">traces</a>) to help you analyze your software’s performance
 and behavior.
 </p>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
 OpenTelemetry is a collection of APIs, SDKs, and tools. Use it to
-instrument, generate, collect, and export telemetry data (<a href="https://opentelemetry.io/docs/concepts/signals/metrics/">metrics</a>, <a href="https://opentelemetry.io/docs/concepts/signals/logs/">logs</a> and <a href="https://opentelemetry.io/docs/concepts/signals/traces/">traces</a>) to help you analyze your software’s performance
+instrument, generate, collect, and export telemetry data (<a href="https://opentelemetry.io/docs/concepts/signals/metrics/">metrics</a>, <a href="https://opentelemetry.io/docs/concepts/signals/logs/">logs</a> and <a href="https://opentelemetry.io/docs/concepts/signals/traces/">traces</a>) to help you analyze your software's performance
 and behavior.
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+<h1 align="center">
+    High-quality, ubiquitous, and portable telemetry to
+    enable effective observability
+</h1>
+
+<p align="center">
+  <a href="https://opentelemetry.io/">
+    <img src="https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.svg" alt="OpenTelemetry logo" height="180">
+  </a>
+</p>
+
+<p align="center">
+OpenTelemetry is a collection of tools, APIs, and SDKs. Use it to
+instrument, generate, collect, and export telemetry data (<a href="https://opentelemetry.io/docs/concepts/signals/metrics/">metrics</a>, <a href="https://opentelemetry.io/docs/concepts/signals/logs/">logs</a> and <a href="https://opentelemetry.io/docs/concepts/signals/traces/">traces</a>) to help you analyze your software’s performance
+and behavior.
+</p>
+
+<p align="center">
+  <a href="https://opentelemetry.io/docs/what-is-opentelemetry/">Learn More 📚</a>
+  ·
+  <a href="https://opentelemetry.io/docs/getting-started/">Get Started 🔭</a>
+  ·
+  <a href="https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md">Contribute 🫶</a>
+  ·
+  <a href="https://opentelemetry.io/docs/demo/">Try the demo 🎓</a>
+</p>
+
+---
+
+## 👋 Getting involved
+
+There is a lot to do! If you are interested in getting involved, please join the [mailing lists](https://github.com/open-telemetry/community#mailing-lists) and [attend the community meetings](https://calendar.google.com/calendar/u/0/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60@group.calendar.google.com). If you're interested in contributing to a specific part of the project, please join the appropriate [special interest group (SIG)](https://github.com/open-telemetry/community#special-interest-groups). We are a friendly, collaborative group and look forward to working together!
+
+Learn more on how you can get involved in the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md).
+
+## 🦺 Help us making this Community safe
+
+OpenTelemetry follows the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Please abide with this Code of Conduct when interacting with all repositories under the OpenTelemetry umbrella and when interacting with people.</sub>
+
+## 👾 Reporting Security Incidents
+
+Please be mindful that Security-related issues should be reported through our [Security Policy](https://github.com/open-telemetry/community/security/policy) as Security-related issues and vulnerabilities can be exploited and we request confidentiality whenever possible.
+
+---
+
+OpenTelemetry is a [CNCF](https://cncf.io/) [incubating](https://www.cncf.io/projects/) project.
+Formed through a merger of the OpenTracing and OpenCensus projects.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and behavior.
 
 ## 👋 Getting involved
 
-There is a lot to do! If you are interested in getting involved, please join the [mailing lists](https://github.com/open-telemetry/community#mailing-lists) and [attend the community meetings](https://calendar.google.com/calendar/u/0/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60@group.calendar.google.com). If you're interested in contributing to a specific part of the project, please join the appropriate [special interest group (SIG)](https://github.com/open-telemetry/community#special-interest-groups). We are a friendly, collaborative group and look forward to working together!
+There is a lot to do! If you are interested in getting involved, please join the [mailing lists](https://github.com/open-telemetry/community#mailing-lists) and [attend the community meetings](https://github.com/open-telemetry/community#calendar). If you're interested in contributing to a specific part of the project, please join the appropriate [special interest group (SIG)](https://github.com/open-telemetry/community#special-interest-groups). We are a friendly, collaborative group and look forward to working together!
 
 Learn more on how you can get involved in the [OpenTelemetry Contributor Guide](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md).
 


### PR DESCRIPTION
I thought it would be nice to have a organization README that is presented on github.com/open-telemetry (as outlined here: https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile)

This is inspired by a few other READMEs that already exist, especially https://github.com/nodejs