### PR TITLE
Update Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,61 @@
-# Code of Conduct
+# OpenTelemetry Community Code of Conduct
 
-OpenTelemetry follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+The OpenTelemetry project aims to be a welcoming place where new and existing
+members feel safe to respectfully share their opinions and disagreements. We
+want to attract a diverse group of people to collaborate with us, which means
+acknowledging that people come from different backgrounds and cultures. 
+
+This project is bound by and abides by the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+Conflicts should be resolved respectfully between the involved parties, however
+we understand that it may not always be possible without outside help or
+mediation. When needed, any community member can ask for help or report a Code
+of Conduct violation to the Governance Committee as outlined below. The project
+prefers for violations to be reported first to the Governance Committee so that
+they may be resolved internally, however, in extreme cases code of conduct
+violations should be reported to the CNCF as outlined in the [CNCF Incident
+Resolution
+Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md).
+Anyone who is unsure if a violation should be reported to the project or the
+CNCF should refer to the [CNCF CoC Jurisdiction
+Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+
+## Reporting violations
+
+If you have seen or experienced unacceptable behavior or anything that would
+make our community less welcoming, please speak up!
+
+When the Governance Committee (GC) determines that a code of conduct violation
+happened, it will take the actions deemed necessary and appropriate for the
+event. In more serious cases, the community member might be requested to depart
+from our communities, giving up any roles they may possess, such as the
+maintainership of a SIG. In extreme cases, the GC can force the departure of the
+member.
+
+## Submit in writing
+
+To report a violation in writing, please email
+cncf-opentelemetry-governance@lists.cncf.io, which goes to all GC members. If
+you do not want your report to be received by all GC members, either because you
+want to submit a report anonymously or because one of the GC members has a
+conflict of interest, you may send your report directly to any individual GC
+member. The [current list of
+members](https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee)
+can be found on our community repository, and you can ping any of them directly
+on [CNCF’s Slack](https://slack.cncf.io)
+
+## Submit in spoken conversation
+
+If you prefer to report the violation in a spoken conversation, you may request
+a telephone conversation or virtual meeting with a GC member.
+
+# How to report anonymously
+
+If you desire to submit a report anonymously, please send a message directly to
+any individual member of our GC through the CNCF Slack and let them know you
+would like to submit a Code of Conduct report anonymously. If you submit your
+report anonymously, that member of the GC will share the contents of your report
+with the rest of the GC, but they will not disclose your identity as the
+reporter to the other members of the GC (unless such disclosure is necessary to
+comply with applicable laws or a court order, or to protect you or someone else
+from imminent danger).


### PR DESCRIPTION
This PR follows up from https://github.com/open-telemetry/community/pull/1655, updating the CoC based on that PR.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
