### PR TITLE
Add OSSF security-insights.yml file

### DIFF
--- a/security-insights.yml
+++ b/security-insights.yml
@@ -18,7 +18,7 @@ project:
     - name: Carlos Alberto
       affiliation: Lightstep
     - name: Daniel Gomez Blanco
-      affiliation: Skyscanner
+      affiliation: New Relic
     - name: Jack Berg
       affiliation: New Relic
     - name: Josh Suereth


### PR DESCRIPTION
See https://github.com/ossf/security-insights-spec

This file in this repo will have the top-level project info, and then the security-insights.yml file we add to other repos will point to this file.

This is following recommendation from CNCF Security Tag.