### PR TITLE
Add link for website vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,9 @@ the preferred way is to use the `Report a vulnerability` button on the `Security
 tab in the respective GitHub repository. It creates a private communication channel
 between the reporter and the maintainers.
 
+For reporting security issues against the website, please report them at
+https://github.com/open-telemetry/opentelemetry.io/security/advisories.
+
 If you are absolutely unable to or have strong reasons not to use GitHub reporting
 workflow, please reach out to security@opentelemetry.io.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ tab in the respective GitHub repository. It creates a private communication chan
 between the reporter and the maintainers.
 
 For reporting security issues against the website, please report them at
-https://github.com/open-telemetry/opentelemetry.io/security/advisories.
+<https://github.com/open-telemetry/opentelemetry.io/security/advisories>.
 
 If you are absolutely unable to or have strong reasons not to use GitHub reporting
 workflow, please reach out to security@opentelemetry.io.


### PR DESCRIPTION
We've had a couple of reports to security@opentelemetry.io for the website, I think it's not clear to people that the website has its own repo where they can report issues directly in github, which is our preference.

cc @open-telemetry/sig-security-approvers 
