### PR TITLE
Restrict Renovate schedules to a 4-hour window and add timezone

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
         'github-actions',
       ],
       schedule: [
-        '* 0-3 2 * *', // monthly, on the 2nd, midnight-4am
+        '* 0-3 2 * *', // monthly, on the 2nd, 00:00–03:59 America/Los_Angeles
       ],
       timezone: 'America/Los_Angeles',
     },
@@ -20,7 +20,7 @@
         '!github-actions',
       ],
       schedule: [
-        '* 0-3 2 * *', // monthly, on the 2nd, midnight-4am
+        '* 0-3 2 * *', // monthly, on the 2nd, 00:00–03:59 America/Los_Angeles
       ],
       timezone: 'America/Los_Angeles',
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,16 +11,18 @@
         'github-actions',
       ],
       schedule: [
-        '* * 2 * *', // monthly, on the 2nd
+        '* 0-3 2 * *', // monthly, on the 2nd, midnight-4am
       ],
+      timezone: 'America/Los_Angeles',
     },
     {
       matchManagers: [
         '!github-actions',
       ],
       schedule: [
-        '* * 2 * *', // monthly, on the 2nd
+        '* 0-3 2 * *', // monthly, on the 2nd, midnight-4am
       ],
+      timezone: 'America/Los_Angeles',
     },
   ],
   "labels": [


### PR DESCRIPTION
This will lessen the likelihood of us merging one PR (https://github.com/open-telemetry/.github/pull/82) only for Renovate to open another PR the same day (https://github.com/open-telemetry/.github/pull/83).
